### PR TITLE
Update Building Rules.html

### DIFF
--- a/Building Rules.html
+++ b/Building Rules.html
@@ -13,8 +13,8 @@
             <div class="subsystem"><p class="rules"> <b>Getting Credits:</b>
                 At the beginning of the Build Phase, each player gets an allowance of new credits 
                 depending on what turn it is and how well they did in the last round. The <b>Loser</b> 
-                of the last round gets the full payout. Each player after that gets 5 fewer credits
-                in the order of people who died.
+                of the last round gets the full payout. Everyone else, other than the Victor, gets 5 fewer 
+		credits. The <b>Victor</b> of the last round gets 10 fewer credits.
             </p>
             <table>
                 <thead>


### PR DESCRIPTION
Technically "You cannot sell more than 4 weapons in a round." isn't correct because I wanted to prevent players from completely respec'ing their mechs in 1 round, but I realized they can still do that by keeping weapons in the "garage" and buying all new ones. So let's leave it for now and see how it plays + this rule is way easier to explain.